### PR TITLE
Testing

### DIFF
--- a/files/apache2-conf/default.conf
+++ b/files/apache2-conf/default.conf
@@ -1,6 +1,7 @@
 <VirtualHost *:80>
   ServerAdmin webmaster@localhost
   DocumentRoot /var/www
+  DirectoryIndex index.html
 
   <Directory />
     Options FollowSymLinks
@@ -41,7 +42,7 @@
   Allow from 172.16.0.0/12
   Allow from 192.168.0.0/16
   </Directory>
-  
+
   # Possible values include:
   # debug, info, notice, warn, error, crit, alert, emerg.
   LogLevel warn

--- a/files/apache2-conf/default.conf
+++ b/files/apache2-conf/default.conf
@@ -1,7 +1,6 @@
 <VirtualHost *:80>
   ServerAdmin webmaster@localhost
   DocumentRoot /var/www
-  DirectoryIndex index.html
 
   <Directory />
     Options FollowSymLinks

--- a/files/apache2-conf/https.conf
+++ b/files/apache2-conf/https.conf
@@ -3,6 +3,7 @@
   ServerAdmin webmaster@localhost
   ServerName client.MASTER_DOMAIN
   DocumentRoot /var/www/
+  DirectoryIndex /Mailpile/
 
   SSLEngine on
   SSLCertificateFile /etc/ssl/server.crt
@@ -10,6 +11,7 @@
 # SSLCertificateChainFile /etc/letsencrypt/live/www.own-mailbox.com/fullchain.pem
   Include /etc/letsencrypt/options-ssl-apache.conf
 
+  Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
   
     <Directory "/usr/lib/cgi-bin">
     AllowOverride None

--- a/setup-scripts/apache.sh
+++ b/setup-scripts/apache.sh
@@ -14,6 +14,9 @@ cp files/options-ssl-apache.conf /etc/letsencrypt/
 a2enmod proxy_http
 a2enmod cgi
 a2enmod ssl
+a2enmod headers
+a2enmod rewrite
+
 a2dissite "*"
 rm /etc/apache2/sites-available/*
 cp files/apache2-conf/* /etc/apache2/sites-available/


### PR DESCRIPTION
I removed the auto-redirect (that I added last week) from HTTP to HTTPS. Of course I kept HSTS and changed the apache.conf a little bit. It is a simple change in the end, but it took a lot of testing. I removed the auto-redirect because:

- HSTS works good without it and we can access the installation from the local network
- If the user tries to access http://whatever.omb.one/Mailpile, he automatically gets redirected to HTTPS anyway
- If the user tries to access http://whatever.omb.one/, he is blocked and asked to go to HTTPS (this is where my redirect was)
- We don't need to change the ihm repository